### PR TITLE
Fix https://nvd.nist.gov/vuln/detail/CVE-2018-18074

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.7.0
+requests==2.20.1


### PR DESCRIPTION
This requirement is currently not used by kirin (which is the only one using this repo).

So no impact except being clean in case of (external) use.