### PR TITLE
Pin pyrsistent to the last py2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.20.1
+pyrsistent==0.15.7


### PR DESCRIPTION
It's blocking installation of request for py2 as:
* 'request' requires pyrsistent>=0.14.
* when installing request, the last version of pyrsistent is used (no other constraint on version)
* pyrsistent>=0.16 is not py2 compliant

so pin to the last py2-valid version of pyrsistent (0.15.7)